### PR TITLE
Do callback when list of redirects of size 0 is returned

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -244,7 +244,8 @@ function AdminCntl($scope, $pekso, $location, $config) {
     $scope.remove = function(row) {
         $pekso.remove(row.key, function(err) {
             if (err) { $scope.err = err; return; }
-            $scope.urls.splice(this.$index, 1);
+            var deleteIndex = $scope.urls.indexOf(row);
+            $scope.urls.splice(deleteIndex, 1);
             $scope.$apply();
         });
     };

--- a/js/app.js
+++ b/js/app.js
@@ -125,17 +125,21 @@ pekso.factory('$pekso', function($fb, $aws) {
 
                     if (key.indexOf('.') !== -1 || key.indexOf('/') !== -1) {
                         --remaining;
-                        continue;
-                    }
-                    $aws.s3().headObject({ Key: key }, function(err, response) {
-                        if (response.WebsiteRedirectLocation) {
-                            requests.push({key: this.request.params.Key, url: response.WebsiteRedirectLocation});
-                        }
-                        --remaining;
                         if (remaining <= 0) {
                             callback(null, requests);
                         }
-                    });
+                        continue;
+                    } else {
+                        $aws.s3().headObject({ Key: key }, function(err, response) {
+                            if (response.WebsiteRedirectLocation) {
+                                requests.push({key: this.request.params.Key, url: response.WebsiteRedirectLocation});
+                            }
+                            --remaining;
+                            if (remaining <= 0) {
+                                callback(null, requests);
+                            }
+                        });
+                    }
                 }
             });
         },


### PR DESCRIPTION
This addresses issue #5.

A more DRY fix would include using a promise with the AWS S3 object list request so that this code only needs to be used once:

``` javascript
if (remaining <= 0) {
  callback(null, requests);
}
```

But if we do that, then for consistency all AWS requests should be updated to use promises instead of nested callbacks.  I didn't want to make that significant a change to the app at this time.
