### PR TITLE
Fix incorrect delete behavior

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -240,7 +240,8 @@ function AdminCntl($scope, $pekso, $location, $config) {
     $scope.remove = function(row) {
         $pekso.remove(row.key, function(err) {
             if (err) { $scope.err = err; return; }
-            $scope.urls.splice(this.$index, 1);
+            var deleteIndex = $scope.urls.indexOf(row);
+            $scope.urls.splice(deleteIndex, 1);
             $scope.$apply();
         });
     };


### PR DESCRIPTION
`this.$index` as used in [this line](https://github.com/Peksa/pek.so/blob/master/js/app.js#L243) is always undefined causing the delete operation to work incorrectly.  It always deletes the first redirect.

This fixes that.
